### PR TITLE
ENHANCED: Allow reproducible builds by using the SOURCE_DATE_EPOCH variable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -11,6 +11,12 @@ include ../Makefile.defs
 CFLAGS+= -I.
 LIBS=@LIBS@
 
+DATE_FMT = %Y-%m-%d
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)"  2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+    CFLAGS += -DBUILD_DATE=\"${BUILD_DATE}\"
+endif
+
 LIBPL=		table.pl table_util.pl
 TARGETS=	table.@SO@
 

--- a/table.c
+++ b/table.c
@@ -38,6 +38,10 @@
 
 #define O_ORDER				/* include order.c package */
 
+#ifndef BUILD_DATE
+#define BUILD_DATE __DATE__
+#endif
+
 #include <SWI-Stream.h>
 
 #include "table.h"
@@ -2198,7 +2202,7 @@ pl_in_table(term_t handle, term_t spec, term_t record, control_t control)
 static foreign_t
 pl_table_version(term_t version, term_t date)
 { if ( PL_unify_atom_chars(version, TABLE_VERSION) &&
-       PL_unify_atom_chars(date, __DATE__) )
+       PL_unify_atom_chars(date, BUILD_DATE) )
     return TRUE;
 
   return FALSE;


### PR DESCRIPTION
To allow reproducible builds (same source results in same binary) replace `__DATE__` with system provided value.

This is related to this PR: https://github.com/SWI-Prolog/swipl-devel/pull/210