### PR TITLE
CLEANUP: use snprintf to avoid deprecation warnings

### DIFF
--- a/error.c
+++ b/error.c
@@ -102,7 +102,7 @@ error_func(int type, const char *pred, int argi, intptr_t argl)
   { case ERR_INSTANTIATION:
     { char buf[1024];
 
-      sprintf(buf, "%s: instantiation error on argument %d", pred, argi);
+      snprintf(buf, sizeof buf, "%s: instantiation error on argument %d", pred, argi);
       return PL_warning("%s", buf);
     }
     case ERR_IO:
@@ -110,10 +110,10 @@ error_func(int type, const char *pred, int argi, intptr_t argl)
 
 #ifdef __WINDOWS__
       char *msg = winerror(argi);
-      sprintf(buf, "%s: IO error %s", pred, msg);
+      snprintf(buf, sizeof buf, "%s: IO error %s", pred, msg);
       free(msg);
 #else
-      sprintf(buf, "%s: IO error %s", pred, strerror(argi));
+      snprintf(buf, sizeof buf, "%s: IO error %s", pred, strerror(argi));
 #endif
 
       return PL_warning("%s", buf);

--- a/error.c
+++ b/error.c
@@ -100,25 +100,19 @@ int
 error_func(int type, const char *pred, int argi, intptr_t argl)
 { switch(type)
   { case ERR_INSTANTIATION:
-    { char buf[1024];
-
-      snprintf(buf, sizeof buf, "%s: instantiation error on argument %d", pred, argi);
-      return PL_warning("%s", buf);
-    }
+      return PL_warning("%s: instantiation error on argument %d", pred, argi);
     case ERR_IO:
-    { char buf[1024];
-
+    { 
 #ifdef __WINDOWS__
       char *msg = winerror(argi);
-      snprintf(buf, sizeof buf, "%s: IO error %s", pred, msg);
+      PL_warning("%s: IO error %s", pred, msg);
       free(msg);
+      return FALSE;
 #else
-      snprintf(buf, sizeof buf, "%s: IO error %s", pred, strerror(argi));
+      return PL_warning("%s: IO error %s", pred, strerror(argi));
 #endif
-
-      return PL_warning("%s", buf);
     }
   }
 
-  return PL_warning("%s", "Table package: unknown error");
+  return PL_warning("Table package: unknown error");
 }

--- a/table.c
+++ b/table.c
@@ -289,7 +289,7 @@ static int
 format_error(const char *pred, size_t pos, Field f)
 { char buf[1024];
 
-  sprintf(buf, "%s: bad record, field %d (%s), char-index %ld",
+  snprintf(buf, sizeof buf, "%s: bad record, field %d (%s), char-index %ld",
 	  pred, f->index, PL_atom_chars(f->name), (long)pos);
 
   return PL_representation_error(buf);


### PR DESCRIPTION
If you wish, I can simplify this further by collapsing char buf[1024] ; snprintf(buf, sizeof buf, "...", ...) ; PL_warning(buf) to just PL_warning("...", ...)